### PR TITLE
Set longer DHCP lease time for AKS vm

### DIFF
--- a/Scenarios/AzSHCI and Kubernetes/Scenario.ps1
+++ b/Scenarios/AzSHCI and Kubernetes/Scenario.ps1
@@ -26,12 +26,13 @@ Foreach ($VM in $VMs){
 ### Run from DC ###
 ###################
 
+#region Create 2 node cluster (just simple. Not for prod - follow hyperconverged scenario for real clusters https://github.com/microsoft/MSLab/tree/master/Scenarios/S2D%20Hyperconverged)
+
 # Set DHCP Server lease time to 90 days for reserving IP dynamicly allocated to AKS management/working cluster control plane & working nodes.
 Invoke-Command -ComputerName DC -ScriptBlock {
     Set-DhcpServerv4Scope -ScopeId 10.0.0.0 -LeaseDuration 90.00:00:00
 }
 
-#region Create 2 node cluster (just simple. Not for prod - follow hyperconverged scenario for real clusters https://github.com/microsoft/MSLab/tree/master/Scenarios/S2D%20Hyperconverged)
 # LabConfig
 $Servers="AzsHCI1","AzSHCI2"
 $ClusterName="AzSHCI-Cluster"

--- a/Scenarios/AzSHCI and Kubernetes/Scenario.ps1
+++ b/Scenarios/AzSHCI and Kubernetes/Scenario.ps1
@@ -26,6 +26,11 @@ Foreach ($VM in $VMs){
 ### Run from DC ###
 ###################
 
+# Set DHCP Server lease time to 90 days for reserving IP dynamicly allocated to AKS management/working cluster control plane & working nodes.
+Invoke-Command -ComputerName DC -ScriptBlock {
+    Set-DhcpServerv4Scope -ScopeId 10.0.0.0 -LeaseDuration 90.00:00:00
+}
+
 #region Create 2 node cluster (just simple. Not for prod - follow hyperconverged scenario for real clusters https://github.com/microsoft/MSLab/tree/master/Scenarios/S2D%20Hyperconverged)
 # LabConfig
 $Servers="AzsHCI1","AzSHCI2"


### PR DESCRIPTION
I found that the default lease time (8 minutes) will easily result to the issue of cannot finding/connecting AKS cluster when restarting host.  When host restart (or shut down for a while), the mgmt. cluster and working cluster VMs might re-allocate new IP address, but based on initial configuration, the ETCD/API-Server will still use old IP to bind/connect, this will mess the entire AKS cluster, so longer DHCP lease time will help to keep the configuration & cluster stable.