### PR TITLE
[WIP] Support for additional network adapters in LabConfig

### DIFF
--- a/Scripts/3_Deploy.ps1
+++ b/Scripts/3_Deploy.ps1
@@ -474,6 +474,34 @@ If (-not $isAdmin) {
             $global:IP++
         }
 
+        if($VMConfig.AdditionalNetworkAdapters) {
+            $networks = $VMConfig.AdditionalNetworkAdapters
+            if($networks -isnot [array]) {
+                $networks = @($networks)
+            }
+
+            foreach ($network in $networks) {
+                $switch = Get-VMSwitch -Name $network.VirtualSwitchName -ErrorAction SilentlyContinue
+                if(-not $switch) {
+                    WriteErrorAndExit "Hyper-V switch $($network.VirtualSwitchName) not found."
+                }
+
+                $adapter = $vmtemp | Add-VMNetworkAdapter -SwitchName $network.VirtualSwitchName -Passthru
+
+                if($network.Mac -and $network.Mac -match "^([0-9A-F][0-9A-F]-){5}[0-9A-F][0-9A-F]$") {
+                    $adapter | Set-VMNetworkAdapter -StaticMacAddress $network.Mac
+                }
+
+                if($network.VlanId -and $network.VlanId -ne 0) {
+                    $adapter | Set-VMNetworkAdapterVlan -VlanId $network.VlanId -Access
+                }
+
+                if($network.IpConfiguration -and $network.IpConfiguration -ne "DHCP" -and $network.IpConfiguration -is [Hashtable]) {
+                    $adapter | Set-VMNetworkConfiguration -IPAddress $network.IpConfiguration.IpAddress -Subnet $network.IpConfiguration.Subnet
+                }
+            }
+        }
+
         #Generate DSC Config
         if ($VMConfig.DSCMode -eq 'Pull'){
             WriteInfo "`t Setting DSC Mode to Pull"

--- a/Scripts/LabConfig.ps1
+++ b/Scripts/LabConfig.ps1
@@ -8,7 +8,6 @@ $LabConfig=@{ DomainAdminName='LabAdmin'; AdminPassword='LS1setup!'; Prefix = 'M
 # Or Windows Server 2019
 #1..4 | ForEach-Object {$VMNames="S2D"; $LABConfig.VMs += @{ VMName = "$VMNames$_" ; Configuration = 'S2D' ; ParentVHD = 'Win2019Core_G2.vhdx'; SSDNumber = 0; SSDSize=800GB ; HDDNumber = 12; HDDSize= 4TB ; MemoryStartupBytes= 512MB }}
 
-
 ### HELP ###
 
 #If you need more help or different configuration options, ping us at jaromir.kaspar@dell.com or vlmach@microsoft.com
@@ -219,6 +218,18 @@ $LabConfig=@{ DomainAdminName='LabAdmin'; AdminPassword='LS1setup!'; Prefix = 'M
 
     AdditionalNetworks (Optional)
         $True - Additional networks (configured in AdditonalNetworkConfig) are added 
+
+    AdditionalNetworkAdapters (Optional) - Hashtable or array if multiple network adapters should be connected to this virtual machine
+        @{
+            VirtualSwitchName  (Mandatory) - Name of the Hyper-V Switch to witch the adapter will be connected
+            Mac                (Optional)  - Static MAC address of the interface otherwise default will be generated
+            VlanId             (Optional)  - VLAN ID for this adapter
+            IpConfiguration    (Optional)  - DHCP or hastable with specific IP configuration
+            @{
+                IpAddress      (Mandatory) - Static IP Address that would be injected to the OS
+                Subnet         (Mandatory) 
+            }     
+        }
 
     DSCMode (Optional)
         If 'Pull', VMs will be configured to Pull config from DC.


### PR DESCRIPTION
Starting this pull request as work in progress to discuss further.

Sample working VM configuration using new options.
```powershell
$LABConfig.VMs += @{ 
    VMName = 'Management' 
    ParentVHD = 'Win10_G2.vhdx' 
    AdditionalNetworkAdapters =
        @{
            VirtualSwitchName = 'Litware-LAN' # mandatory 
            Mac = '00-0C-29-04-8D-C6' 
            VlanId = 15 # Optional parameter if VLANs are used in the environment
            IpConfiguration = @{ # DHCP or specific IP set with Set-VMNetworkConfiguration function
               IpAddress = '172.17.1.15'
               Subnet = '255.255.255.0'
            }
        },
        @{
            VirtualSwitchName = 'Litware-LAN' # mandatory 
            IpConfiguration = @{
                IpAddress = '172.17.1.16'
                Subnet = '255.255.255.0'
            }
        }
  }
```