### PR TITLE
avoid re-create volume in case of retry

### DIFF
--- a/Scenarios/AzSHCI and Kubernetes/Scenario.ps1
+++ b/Scenarios/AzSHCI and Kubernetes/Scenario.ps1
@@ -269,8 +269,11 @@ Foreach ($PSSession in $PSSessions){
         Initialize-AksHciNode
     }
 
-    #Create  volume for AKS
-    New-Volume -FriendlyName $VolumeName -CimSession $ClusterName -Size 1TB -StoragePoolFriendlyName S2D*
+    #Create volume for AKS if does not exist
+    if (-not (Get-Volume -FriendlyName $VolumeName -CimSession $ClusterName)) {
+        New-Volume -FriendlyName $VolumeName -CimSession $ClusterName -Size 1TB -StoragePoolFriendlyName S2D*
+    }
+    
     #make sure failover clustering management tools are installed on nodes
     Invoke-Command -ComputerName $servers -ScriptBlock {
         Install-WindowsFeature -Name RSAT-Clustering-PowerShell


### PR DESCRIPTION
Firstly to check whether the volume exists then to create it, so that avoiding create multiple aks volume in case of re-executing script block when error occurs.