### PR TITLE
Update 3_Deploy.ps1 - adjust startup RAM to comply with Windows Server in-place upgrade requirements

### DIFF
--- a/Scripts/3_Deploy.ps1
+++ b/Scripts/3_Deploy.ps1
@@ -1493,9 +1493,9 @@ If (-not $isAdmin) {
                 if(-not $VMConfig.configuration) {
                     $VMConfig.configuration = "Simple"
                 }
-                # Ensure that MemoryStartupBytes is set to use 512MB as default
+                # Ensure that MemoryStartupBytes is set to use 2048MB as default
                 if(-not $VMConfig.MemoryStartupBytes) {
-                    $VMConfig.MemoryStartupBytes = 512MB
+                    $VMConfig.MemoryStartupBytes = 2048MB
                 }
 
                 #create VM with Shared configuration


### PR DESCRIPTION
raised Startup minimum RAM from 512MB to 2048MB to avoid unexpected issues during initial setup phase and setup phase during in-place upgrade