### PR TITLE
Update 1_Prereq.ps1 - updated diskspd Link to version 2.2

### DIFF
--- a/Scripts/1_Prereq.ps1
+++ b/Scripts/1_Prereq.ps1
@@ -178,7 +178,7 @@ function  Get-WindowsBuildNumber {
                 $downloadurl = $webcontent.BaseResponse.ResponseUri.AbsoluteUri.Substring(0,$webcontent.BaseResponse.ResponseUri.AbsoluteUri.LastIndexOf('/'))+($webcontent.Links | where-object { $_.'data-url' -match '/Diskspd.*zip$' }|Select-Object -ExpandProperty "data-url")
             }
             #>
-            $downloadurl="https://github.com/microsoft/diskspd/releases/download/v2.1/DiskSpd.ZIP"
+            $downloadurl="https://github.com/microsoft/diskspd/releases/download/v2.2/DiskSpd.ZIP"
             Invoke-WebRequest -Uri $downloadurl -OutFile "$PSScriptRoot\Temp\ToolsVHD\DiskSpd\diskspd.zip"
         }catch{
             WriteError "`t Failed to download Diskspd!"


### PR DESCRIPTION
mslab will download an outdated diskspd version, which is crucial being updated for scenarios like VMfleet. 
The latest DiskSPD 2.2 offers significant improvements.